### PR TITLE
Added a new resource module for interacting with the Account Billing Profile API Endpoint

### DIFF
--- a/lib/cloudflare/resources/account_billing_profile.ex
+++ b/lib/cloudflare/resources/account_billing_profile.ex
@@ -1,0 +1,8 @@
+defmodule Cloudflare.AccountBillingProfile do
+  use Cloudflare.Doc, "account_billing_profile"
+
+  use Restlax.Resource,
+    endpoint: "accounts/:account_id/billing/profile",
+    only: [:show],
+    singular: true
+end

--- a/test/cloudflare/resources/account_billing_profile_test.exs
+++ b/test/cloudflare/resources/account_billing_profile_test.exs
@@ -1,0 +1,15 @@
+defmodule Cloudflare.AccountBillingProfileTest do
+  use ExUnit.Case, async: true
+
+  alias Cloudflare.AccountBillingProfile
+
+  doctest AccountBillingProfile
+
+  test "module is defined" do
+    assert is_list(AccountBillingProfile.__info__(:functions))
+  end
+
+  test "show/1 function is defined" do
+    assert function_exported?(AccountBillingProfile, :show, 1)
+  end
+end


### PR DESCRIPTION
…ling Profile API endpoint (`/accounts/:account_id/billing/profile`).

The module `Cloudflare.AccountBillingProfile` is defined in `lib/cloudflare/resources/account_billing_profile.ex`. It uses `Cloudflare.Doc` to link to the relevant markdown documentation and `Restlax.Resource` to define the `:show` action for the singular resource.

I've also added some basic tests in `test/cloudflare/resources/account_billing_profile_test.exs` to ensure the module is correctly defined and exports the necessary `show/1` function.